### PR TITLE
PR for Mod Compatibility with Public Gui Announcement

### DIFF
--- a/src/main/resources/assets/snowmancy/load_screens/snowmancy_compat_pga.json
+++ b/src/main/resources/assets/snowmancy/load_screens/snowmancy_compat_pga.json
@@ -1,0 +1,10 @@
+{
+	"screens" : [
+		
+		 {
+			"COMMENT" : "SNOWMANCY SUPPORT", 
+			"class" : "bl4ckscor3.mod.snowmancy.gui.GuiSnowmanBuilder", 
+			"texture" : "snowmancy:textures/gui/container/snowman_builder.png", 
+			"size" : [177, 240]
+		}]
+}


### PR DESCRIPTION
the PGA :
https://www.curseforge.com/minecraft/mc-mods/public-gui-announcement

The Wiki on how these JSON files work :
https://github.com/ArtixAllMighty/PublicGuiAnnouncement/wiki/Add-Mod-Compatibility

In this PR is contained one json file to add compatibility with the mod Public Gui Announcement.
I wanted to ship the compat at first with my mod, but it would be better if the author maintains it himself. (in case of path and name changes as well addition or removal from screens).

I hereby give you all files needed to add compatibility to my mod. There is nothing else left to do apart from merging the PR.

If you have any other question, I'd be happy to answer !